### PR TITLE
Refactor image processing with interface-based design

### DIFF
--- a/api_client_interface.go
+++ b/api_client_interface.go
@@ -1,0 +1,11 @@
+package jplaw2epub
+
+import lawapi "go.ngs.io/jplaw-api-v2"
+
+// APIClient defines the interface for the law API client
+type APIClient interface {
+	GetAttachment(lawRevisionID string, params *lawapi.GetAttachmentParams) (*string, error)
+}
+
+// Ensure lawapi.Client implements APIClient
+var _ APIClient = (*lawapi.Client)(nil)

--- a/appdx.go
+++ b/appdx.go
@@ -10,7 +10,7 @@ import (
 const htmlDivEnd = "</div>"
 
 // processAppdxStyles processes AppdxStyle elements (appendix styles)
-func processAppdxStyles(book *epub.Epub, styles []jplaw.AppdxStyle, imgProc *ImageProcessor) error {
+func processAppdxStyles(book *epub.Epub, styles []jplaw.AppdxStyle, imgProc ImageProcessorInterface) error {
 	if len(styles) == 0 {
 		return nil
 	}
@@ -36,7 +36,7 @@ func processAppdxStyles(book *epub.Epub, styles []jplaw.AppdxStyle, imgProc *Ima
 }
 
 // processAppdxStyle processes a single AppdxStyle
-func processAppdxStyle(book *epub.Epub, style *jplaw.AppdxStyle, parentFilename string, idx int, imgProc *ImageProcessor) error {
+func processAppdxStyle(book *epub.Epub, style *jplaw.AppdxStyle, parentFilename string, idx int, imgProc ImageProcessorInterface) error {
 	// Build the body content
 	body := ""
 
@@ -78,7 +78,7 @@ func processAppdxStyle(book *epub.Epub, style *jplaw.AppdxStyle, parentFilename 
 }
 
 // processAppdxRemark processes a single remark in appendix
-func processAppdxRemark(remark *jplaw.Remarks, imgProc *ImageProcessor) string {
+func processAppdxRemark(remark *jplaw.Remarks, imgProc ImageProcessorInterface) string {
 	html := "<div class='appdx-remarks'>"
 	html += "<div class='remark'>"
 
@@ -104,7 +104,7 @@ func processAppdxRemark(remark *jplaw.Remarks, imgProc *ImageProcessor) string {
 }
 
 // processAppdxFig processes AppdxFig elements (appendix figures)
-func processAppdxFig(book *epub.Epub, figures []jplaw.AppdxFig, imgProc *ImageProcessor) error {
+func processAppdxFig(book *epub.Epub, figures []jplaw.AppdxFig, imgProc ImageProcessorInterface) error {
 	if len(figures) == 0 {
 		return nil
 	}
@@ -130,7 +130,7 @@ func processAppdxFig(book *epub.Epub, figures []jplaw.AppdxFig, imgProc *ImagePr
 }
 
 // processAppdxFigItem processes a single AppdxFig
-func processAppdxFigItem(book *epub.Epub, fig *jplaw.AppdxFig, parentFilename string, idx int, imgProc *ImageProcessor) error {
+func processAppdxFigItem(book *epub.Epub, fig *jplaw.AppdxFig, parentFilename string, idx int, imgProc ImageProcessorInterface) error {
 	// Build the body content
 	body := ""
 

--- a/appdx_note.go
+++ b/appdx_note.go
@@ -11,7 +11,7 @@ import (
 const defaultAppdxNoteTitle = "附則"
 
 // processAppdxNotes processes appendix notes
-func processAppdxNotes(book *epub.Epub, notes []jplaw.AppdxNote, imgProc *ImageProcessor) error {
+func processAppdxNotes(book *epub.Epub, notes []jplaw.AppdxNote, imgProc ImageProcessorInterface) error {
 	if len(notes) == 0 {
 		return nil
 	}
@@ -26,7 +26,7 @@ func processAppdxNotes(book *epub.Epub, notes []jplaw.AppdxNote, imgProc *ImageP
 }
 
 // processAppdxNote processes a single appendix note
-func processAppdxNote(book *epub.Epub, note *jplaw.AppdxNote, idx int, imgProc *ImageProcessor) error {
+func processAppdxNote(book *epub.Epub, note *jplaw.AppdxNote, idx int, imgProc ImageProcessorInterface) error {
 	filename := fmt.Sprintf("appdx-note-%d.xhtml", idx)
 	body := ""
 
@@ -81,7 +81,7 @@ func processAppdxNote(book *epub.Epub, note *jplaw.AppdxNote, idx int, imgProc *
 }
 
 // processNoteStruct processes a NoteStruct
-func processNoteStruct(noteStruct *jplaw.NoteStruct, imgProc *ImageProcessor) string {
+func processNoteStruct(noteStruct *jplaw.NoteStruct, imgProc ImageProcessorInterface) string {
 	body := `<div class="note-struct">`
 
 	// Add title if present
@@ -108,7 +108,7 @@ func processNoteStruct(noteStruct *jplaw.NoteStruct, imgProc *ImageProcessor) st
 }
 
 // processNoteContent processes the inner content of a Note
-func processNoteContent(content string, imgProc *ImageProcessor) string {
+func processNoteContent(content string, imgProc ImageProcessorInterface) string {
 	// Parse the XML content as a fragment
 	// We'll wrap it in a root element to make it valid XML
 	wrappedContent := "<root>" + content + "</root>"
@@ -158,7 +158,7 @@ func processRemarks(remarks *jplaw.Remarks) string {
 }
 
 // processAppdxTables processes appendix tables
-func processAppdxTables(book *epub.Epub, tables []jplaw.AppdxTable, imgProc *ImageProcessor) error {
+func processAppdxTables(book *epub.Epub, tables []jplaw.AppdxTable, imgProc ImageProcessorInterface) error {
 	if len(tables) == 0 {
 		return nil
 	}
@@ -173,7 +173,7 @@ func processAppdxTables(book *epub.Epub, tables []jplaw.AppdxTable, imgProc *Ima
 }
 
 // processAppdxTable processes a single appendix table
-func processAppdxTable(book *epub.Epub, table *jplaw.AppdxTable, idx int, imgProc *ImageProcessor) error {
+func processAppdxTable(book *epub.Epub, table *jplaw.AppdxTable, idx int, imgProc ImageProcessorInterface) error {
 	filename := fmt.Sprintf("appdx-table-%d.xhtml", idx)
 	body := ""
 

--- a/chapter.go
+++ b/chapter.go
@@ -8,7 +8,7 @@ import (
 )
 
 // processChapterWithImages processes a single chapter with image support
-func processChapterWithImages(book *epub.Epub, chapter *jplaw.Chapter, chapterIdx int, imgProc *ImageProcessor) error {
+func processChapterWithImages(book *epub.Epub, chapter *jplaw.Chapter, chapterIdx int, imgProc ImageProcessorInterface) error {
 	chapterFilename := fmt.Sprintf("chapter-%d.xhtml", chapterIdx)
 	body := buildChapterBody(chapter)
 

--- a/format.go
+++ b/format.go
@@ -8,7 +8,7 @@ import (
 )
 
 // processAppdxFormats processes appendix formats
-func processAppdxFormats(book *epub.Epub, formats []jplaw.AppdxFormat, imgProc *ImageProcessor) error {
+func processAppdxFormats(book *epub.Epub, formats []jplaw.AppdxFormat, imgProc ImageProcessorInterface) error {
 	if len(formats) == 0 {
 		return nil
 	}
@@ -23,7 +23,7 @@ func processAppdxFormats(book *epub.Epub, formats []jplaw.AppdxFormat, imgProc *
 }
 
 // processAppdxFormat processes a single appendix format
-func processAppdxFormat(book *epub.Epub, format *jplaw.AppdxFormat, idx int, imgProc *ImageProcessor) error {
+func processAppdxFormat(book *epub.Epub, format *jplaw.AppdxFormat, idx int, imgProc ImageProcessorInterface) error {
 	filename := fmt.Sprintf("appdx-format-%d.xhtml", idx)
 	body := ""
 
@@ -55,7 +55,7 @@ func processAppdxFormat(book *epub.Epub, format *jplaw.AppdxFormat, idx int, img
 }
 
 // processFormatStruct processes a FormatStruct
-func processFormatStruct(formatStruct *jplaw.FormatStruct, imgProc *ImageProcessor) string {
+func processFormatStruct(formatStruct *jplaw.FormatStruct, imgProc ImageProcessorInterface) string {
 	body := `<div class="format-struct">`
 
 	// Add title if present
@@ -77,7 +77,7 @@ func processFormatStruct(formatStruct *jplaw.FormatStruct, imgProc *ImageProcess
 }
 
 // processFormat processes a Format element which contains raw XML
-func processFormat(format *jplaw.Format, imgProc *ImageProcessor) string {
+func processFormat(format *jplaw.Format, imgProc ImageProcessorInterface) string {
 	body := `<div class="format-content">`
 
 	// Format.Content contains raw XML that may include Fig elements
@@ -104,7 +104,7 @@ func containsFigElement(content string) bool {
 }
 
 // processEmbeddedFigs processes Fig elements embedded in XML content
-func processEmbeddedFigs(content string, _ *ImageProcessor) string {
+func processEmbeddedFigs(content string, _ ImageProcessorInterface) string {
 	// For simplicity, just display the content
 	// In a real implementation, we'd parse the XML and extract Fig elements
 	return fmt.Sprintf(`<div class="embedded-content">%s</div>`, content)

--- a/format_test.go
+++ b/format_test.go
@@ -1,0 +1,438 @@
+package jplaw2epub
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-shiori/go-epub"
+	"go.ngs.io/jplaw-xml"
+)
+
+func TestProcessAppdxFormats(t *testing.T) {
+	tests := []struct {
+		name    string
+		formats []jplaw.AppdxFormat
+		wantErr bool
+	}{
+		{
+			name:    "empty formats",
+			formats: []jplaw.AppdxFormat{},
+			wantErr: false,
+		},
+		{
+			name: "single format",
+			formats: []jplaw.AppdxFormat{
+				{
+					AppdxFormatTitle: &jplaw.AppdxFormatTitle{
+						Content: "様式第一",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple formats",
+			formats: []jplaw.AppdxFormat{
+				{
+					AppdxFormatTitle: &jplaw.AppdxFormatTitle{
+						Content: "様式第一",
+					},
+				},
+				{
+					AppdxFormatTitle: &jplaw.AppdxFormatTitle{
+						Content: "様式第二",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			book, err := epub.NewEpub("Test Book")
+			if err != nil {
+				t.Fatalf("Failed to create EPUB: %v", err)
+			}
+
+			err = processAppdxFormats(book, tt.formats, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("processAppdxFormats() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestProcessAppdxFormat(t *testing.T) {
+	tests := []struct {
+		name         string
+		format       *jplaw.AppdxFormat
+		idx          int
+		wantContains []string
+		wantErr      bool
+	}{
+		{
+			name: "format with title and related article",
+			format: &jplaw.AppdxFormat{
+				AppdxFormatTitle: &jplaw.AppdxFormatTitle{
+					Content: "申請書様式",
+				},
+				RelatedArticleNum: &jplaw.RelatedArticleNum{
+					Content: "（第十条関係）",
+				},
+				FormatStruct: []jplaw.FormatStruct{
+					{
+						FormatStructTitle: &jplaw.FormatStructTitle{
+							Content: "申請書",
+						},
+					},
+				},
+			},
+			idx: 0,
+			wantContains: []string{
+				"申請書様式",
+				"（第十条関係）",
+			},
+			wantErr: false,
+		},
+		{
+			name: "format with ruby text",
+			format: &jplaw.AppdxFormat{
+				AppdxFormatTitle: &jplaw.AppdxFormatTitle{
+					Content: "様式",
+					Ruby: []jplaw.Ruby{
+						{
+							Content: "様式",
+							Rt:      []jplaw.Rt{{Content: "ようしき"}},
+						},
+					},
+				},
+			},
+			idx:     1,
+			wantErr: false,
+		},
+		{
+			name: "format without title",
+			format: &jplaw.AppdxFormat{
+				FormatStruct: []jplaw.FormatStruct{
+					{
+						FormatStructTitle: &jplaw.FormatStructTitle{
+							Content: "記載例",
+						},
+					},
+				},
+			},
+			idx:     2,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			book, err := epub.NewEpub("Test Book")
+			if err != nil {
+				t.Fatalf("Failed to create EPUB: %v", err)
+			}
+
+			err = processAppdxFormat(book, tt.format, tt.idx, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("processAppdxFormat() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestProcessFormatStruct(t *testing.T) {
+	tests := []struct {
+		name         string
+		formatStruct *jplaw.FormatStruct
+		wantContains []string
+	}{
+		{
+			name: "with title",
+			formatStruct: &jplaw.FormatStruct{
+				FormatStructTitle: &jplaw.FormatStructTitle{
+					Content: "書式タイトル",
+				},
+			},
+			wantContains: []string{
+				`<h3>書式タイトル</h3>`,
+			},
+		},
+		{
+			name: "with format content",
+			formatStruct: &jplaw.FormatStruct{
+				Format: jplaw.Format{
+					Content: "申請書の内容",
+				},
+			},
+			wantContains: []string{
+				"申請書の内容",
+			},
+		},
+		{
+			name: "with ruby in title",
+			formatStruct: &jplaw.FormatStruct{
+				FormatStructTitle: &jplaw.FormatStructTitle{
+					Content: "申請",
+					Ruby: []jplaw.Ruby{
+						{
+							Content: "申請",
+							Rt:      []jplaw.Rt{{Content: "しんせい"}},
+						},
+					},
+				},
+			},
+			wantContains: []string{
+				"<h3>",
+				"申請",
+				"しんせい",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := processFormatStruct(tt.formatStruct, nil)
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(result, want) {
+					t.Errorf("processFormatStruct() missing expected content: %s", want)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessFormat(t *testing.T) {
+	tests := []struct {
+		name         string
+		format       *jplaw.Format
+		wantContains []string
+	}{
+		{
+			name: "simple format",
+			format: &jplaw.Format{
+				Content: "書式の内容がここに入ります",
+			},
+			wantContains: []string{
+				`<div class="format-content">`,
+				`<pre class="format-raw">`,
+				"書式の内容がここに入ります",
+				`</div>`,
+			},
+		},
+		{
+			name: "format with Fig element",
+			format: &jplaw.Format{
+				Content: "内容 <Fig src=\"image.jpg\"/> テキスト",
+			},
+			wantContains: []string{
+				`<div class="format-content">`,
+				`<pre class="format-raw">`,
+				"内容 <Fig src=\"image.jpg\"/> テキスト",
+				`</div>`,
+			},
+		},
+		{
+			name: "format with multiple lines",
+			format: &jplaw.Format{
+				Content: "第一行\n第二行\n第三行",
+			},
+			wantContains: []string{
+				"第一行",
+				"第二行",
+				"第三行",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := processFormat(tt.format, nil)
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(result, want) {
+					t.Errorf("processFormat() missing expected content: %s\nGot: %s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestContainsFigElement(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "starts with Fig element",
+			content: "<Fig src=\"image.jpg\"/> more text",
+			want:    true,
+		},
+		{
+			name:    "starts with Fig with attributes",
+			content: "<Fig src=\"test.png\" alt=\"description\"/>",
+			want:    true,
+		},
+		{
+			name:    "no Fig element",
+			content: "just plain text without images",
+			want:    false,
+		},
+		{
+			name:    "Fig in middle of content",
+			content: "text <Fig src=\"test.jpg\"/> more",
+			want:    false, // Only checks start
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsFigElement(tt.content); got != tt.want {
+				t.Errorf("containsFigElement() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProcessEmbeddedFigs(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "single Fig element",
+			content: "前文 <Fig src=\"image1.jpg\"/> 後文",
+			want:    `<div class="embedded-content">前文 <Fig src="image1.jpg"/> 後文</div>`,
+		},
+		{
+			name:    "multiple Fig elements",
+			content: "<Fig src=\"img1.jpg\"/> text <Fig src=\"img2.png\"/>",
+			want:    `<div class="embedded-content"><Fig src="img1.jpg"/> text <Fig src="img2.png"/></div>`,
+		},
+		{
+			name:    "Fig with various attributes",
+			content: "text <Fig src=\"test.jpg\" alt=\"desc\" width=\"100\"/> end",
+			want:    `<div class="embedded-content">text <Fig src="test.jpg" alt="desc" width="100"/> end</div>`,
+		},
+		{
+			name:    "no Fig elements",
+			content: "plain text without any figures",
+			want:    `<div class="embedded-content">plain text without any figures</div>`,
+		},
+		{
+			name:    "nested Fig-like text",
+			content: "text about <Figure> but not <Fig src=\"real.jpg\"/> tag",
+			want:    `<div class="embedded-content">text about <Figure> but not <Fig src="real.jpg"/> tag</div>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := processEmbeddedFigs(tt.content, nil)
+			if got != tt.want {
+				t.Errorf("processEmbeddedFigs() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProcessFormatWithMockImageProcessor(t *testing.T) {
+	// Create a mock image processor
+	mock := &MockImageProcessor{
+		ProcessFigStructHTML: `<img src="mocked.jpg" alt="Mocked Image"/>`,
+	}
+
+	format := &jplaw.Format{
+		Content: "書式内容",
+	}
+
+	result := processFormat(format, mock)
+
+	if !strings.Contains(result, "書式内容") {
+		t.Errorf("processFormat() should contain format content")
+	}
+
+	// Verify mock wasn't called since there are no FigStructs in Format
+	if len(mock.ProcessFigStructCalls) != 0 {
+		t.Errorf("ProcessFigStruct should not be called for regular format content")
+	}
+}
+
+func TestProcessAppdxFormatIntegration(t *testing.T) {
+	book, err := epub.NewEpub("Test Book")
+	if err != nil {
+		t.Fatalf("Failed to create EPUB: %v", err)
+	}
+
+	format := &jplaw.AppdxFormat{
+		AppdxFormatTitle: &jplaw.AppdxFormatTitle{
+			Content: "統合テスト様式",
+		},
+		RelatedArticleNum: &jplaw.RelatedArticleNum{
+			Content: "（第一条関係）",
+		},
+		FormatStruct: []jplaw.FormatStruct{
+			{
+				FormatStructTitle: &jplaw.FormatStructTitle{
+					Content: "記載例",
+				},
+				Format: jplaw.Format{
+					Content: "氏名：＿＿＿＿＿＿＿\n住所：＿＿＿＿＿＿＿",
+				},
+			},
+		},
+		Remarks: &jplaw.Remarks{
+			RemarksLabel: jplaw.RemarksLabel{
+				Content: "備考",
+			},
+			Sentence: []jplaw.Sentence{
+				{
+					MixedContent: jplaw.MixedContent{
+						Nodes: []jplaw.ContentNode{
+							jplaw.TextNode{Text: "記入にあたっては黒インクを使用すること"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err = processAppdxFormat(book, format, 0, nil)
+	if err != nil {
+		t.Errorf("processAppdxFormat() unexpected error: %v", err)
+	}
+}
+
+// Benchmark tests
+func BenchmarkProcessFormat(b *testing.B) {
+	format := &jplaw.Format{
+		Content: "これは書式のベンチマークテストです。<Fig src=\"test.jpg\"/> 複数行の\n内容を\n含みます。",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = processFormat(format, nil)
+	}
+}
+
+func BenchmarkContainsFigElement(b *testing.B) {
+	content := "Long text with <Fig src=\"image.jpg\"/> embedded figure element and more text afterwards"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = containsFigElement(content)
+	}
+}
+
+func BenchmarkProcessEmbeddedFigs(b *testing.B) {
+	content := "<Fig src=\"1.jpg\"/> text <Fig src=\"2.jpg\"/> more <Fig src=\"3.jpg\"/> end"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = processEmbeddedFigs(content, nil)
+	}
+}

--- a/images.go
+++ b/images.go
@@ -20,7 +20,7 @@ import (
 
 // ImageProcessor handles image processing for EPUB
 type ImageProcessor struct {
-	client         *lawapi.Client
+	client         APIClient
 	revisionID     string
 	book           *epub.Epub
 	imageCache     map[string]string // maps src to EPUB internal path
@@ -28,7 +28,7 @@ type ImageProcessor struct {
 }
 
 // NewImageProcessor creates a new image processor
-func NewImageProcessor(client *lawapi.Client, revisionID string, book *epub.Epub) *ImageProcessor {
+func NewImageProcessor(client APIClient, revisionID string, book *epub.Epub) *ImageProcessor {
 	return &ImageProcessor{
 		client:         client,
 		revisionID:     revisionID,

--- a/images_client_mock_test.go
+++ b/images_client_mock_test.go
@@ -1,0 +1,483 @@
+package jplaw2epub
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"strings"
+	"testing"
+
+	"github.com/go-shiori/go-epub"
+	lawapi "go.ngs.io/jplaw-api-v2"
+	"go.ngs.io/jplaw-xml"
+)
+
+// MockAPIClient mocks the lawapi.Client for testing
+type MockAPIClient struct {
+	// GetAttachment behavior control
+	GetAttachmentFunc func(lawRevisionID string, params *lawapi.GetAttachmentParams) (*string, error)
+	GetAttachmentErr  error
+	GetAttachmentData map[string]string // Map of src to base64 encoded data
+
+	// Track calls
+	GetAttachmentCalls []struct {
+		RevisionID string
+		Params     *lawapi.GetAttachmentParams
+	}
+}
+
+// GetAttachment mocks the GetAttachment method
+func (m *MockAPIClient) GetAttachment(lawRevisionID string, params *lawapi.GetAttachmentParams) (*string, error) {
+	// Track the call
+	m.GetAttachmentCalls = append(m.GetAttachmentCalls, struct {
+		RevisionID string
+		Params     *lawapi.GetAttachmentParams
+	}{
+		RevisionID: lawRevisionID,
+		Params:     params,
+	})
+
+	// Use custom function if provided
+	if m.GetAttachmentFunc != nil {
+		return m.GetAttachmentFunc(lawRevisionID, params)
+	}
+
+	// Return error if set
+	if m.GetAttachmentErr != nil {
+		return nil, m.GetAttachmentErr
+	}
+
+	// Return data from map if available
+	if m.GetAttachmentData != nil && params != nil && params.Src != nil {
+		if data, ok := m.GetAttachmentData[*params.Src]; ok {
+			return &data, nil
+		}
+	}
+
+	// Default: return empty string
+	empty := ""
+	return &empty, nil
+}
+
+// Helper function to create a simple PNG image
+func createTestPNGData(width, height int, fillColor color.Color) ([]byte, error) {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+
+	// Fill with color
+	for x := 0; x < width; x++ {
+		for y := 0; y < height; y++ {
+			img.Set(x, y, fillColor)
+		}
+	}
+
+	var buf bytes.Buffer
+	err := png.Encode(&buf, img)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// Helper function to create base64 encoded PNG data
+func createBase64PNG() string {
+	data, _ := createTestPNGData(10, 10, color.RGBA{255, 0, 0, 255})
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+const (
+	testRevisionID     = "test-revision"
+	defaultImageHeight = "80vh"
+)
+
+func TestImageProcessorWithMockClient(t *testing.T) {
+	tests := []struct {
+		name             string
+		setupMock        func(*MockAPIClient)
+		fig              *jplaw.FigStruct
+		wantErr          bool
+		wantErrContains  string
+		wantHTMLContains []string
+	}{
+		{
+			name: "successful image download and processing",
+			setupMock: func(m *MockAPIClient) {
+				m.GetAttachmentData = map[string]string{
+					"test.png": createBase64PNG(),
+				}
+			},
+			fig: &jplaw.FigStruct{
+				Fig: jplaw.Fig{
+					Src: "test.png",
+				},
+				FigStructTitle: &jplaw.FigStructTitle{
+					Content: "テスト画像",
+				},
+			},
+			wantErr: false,
+			wantHTMLContains: []string{
+				`<div class="figure"`,
+				`<img`,
+				`alt="Figure"`,
+				`<p class="figure-title">テスト画像</p>`,
+			},
+		},
+		{
+			name: "image download error",
+			setupMock: func(m *MockAPIClient) {
+				m.GetAttachmentErr = fmt.Errorf("network error")
+			},
+			fig: &jplaw.FigStruct{
+				Fig: jplaw.Fig{
+					Src: "error.png",
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "downloading image",
+		},
+		{
+			name: "cached image",
+			setupMock: func(m *MockAPIClient) {
+				// No setup needed - we'll test caching behavior
+				m.GetAttachmentData = map[string]string{
+					"cached.png": createBase64PNG(),
+				}
+			},
+			fig: &jplaw.FigStruct{
+				Fig: jplaw.Fig{
+					Src: "cached.png",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty src",
+			setupMock: func(m *MockAPIClient) {
+				// No setup needed
+			},
+			fig: &jplaw.FigStruct{
+				Fig: jplaw.Fig{
+					Src: "",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with remarks",
+			setupMock: func(m *MockAPIClient) {
+				m.GetAttachmentData = map[string]string{
+					"with-remarks.png": createBase64PNG(),
+				}
+			},
+			fig: &jplaw.FigStruct{
+				Fig: jplaw.Fig{
+					Src: "with-remarks.png",
+				},
+				Remarks: []jplaw.Remarks{
+					{
+						RemarksLabel: jplaw.RemarksLabel{
+							Content: "備考",
+						},
+						Sentence: []jplaw.Sentence{
+							{
+								MixedContent: jplaw.MixedContent{
+									Nodes: []jplaw.ContentNode{
+										jplaw.TextNode{Text: "これは備考です"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantHTMLContains: []string{
+				`<div class="figure"`,
+				`<div class="figure-remark">`,
+				`<p class="remarks-label">備考</p>`,
+				"これは備考です",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock client
+			mockClient := &MockAPIClient{}
+			if tt.setupMock != nil {
+				tt.setupMock(mockClient)
+			}
+
+			// Create EPUB book
+			book, err := epub.NewEpub("Test Book")
+			if err != nil {
+				t.Fatalf("Failed to create EPUB: %v", err)
+			}
+
+			// Create ImageProcessor with mock client
+			imgProc := &ImageProcessor{
+				client:         mockClient,
+				revisionID:     testRevisionID,
+				book:           book,
+				imageCache:     make(map[string]string),
+				maxImageHeight: defaultImageHeight,
+			}
+
+			// Process the figure
+			html, err := imgProc.ProcessFigStruct(tt.fig)
+
+			// Check error
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ProcessFigStruct() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil && tt.wantErrContains != "" {
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("ProcessFigStruct() error = %v, want error containing %v", err, tt.wantErrContains)
+				}
+				return
+			}
+
+			// Check HTML output
+			for _, want := range tt.wantHTMLContains {
+				if !strings.Contains(html, want) {
+					t.Errorf("ProcessFigStruct() HTML missing expected content: %s\nGot: %s", want, html)
+				}
+			}
+		})
+	}
+}
+
+func TestImageProcessorCaching(t *testing.T) {
+	// Create mock client with tracking
+	mockClient := &MockAPIClient{
+		GetAttachmentData: map[string]string{
+			"test.png": createBase64PNG(),
+		},
+	}
+
+	book, err := epub.NewEpub("Test Book")
+	if err != nil {
+		t.Fatalf("Failed to create EPUB: %v", err)
+	}
+
+	imgProc := &ImageProcessor{
+		client:         mockClient,
+		revisionID:     testRevisionID,
+		book:           book,
+		imageCache:     make(map[string]string),
+		maxImageHeight: defaultImageHeight,
+	}
+
+	fig := &jplaw.FigStruct{
+		Fig: jplaw.Fig{
+			Src: "test.png",
+		},
+	}
+
+	// First call - should download
+	_, err = imgProc.ProcessFigStruct(fig)
+	if err != nil {
+		t.Errorf("First ProcessFigStruct() unexpected error: %v", err)
+	}
+
+	if len(mockClient.GetAttachmentCalls) != 1 {
+		t.Errorf("Expected 1 GetAttachment call, got %d", len(mockClient.GetAttachmentCalls))
+	}
+
+	// Second call - should use cache
+	_, err = imgProc.ProcessFigStruct(fig)
+	if err != nil {
+		t.Errorf("Second ProcessFigStruct() unexpected error: %v", err)
+	}
+
+	// Should still be only 1 call (cached)
+	if len(mockClient.GetAttachmentCalls) != 1 {
+		t.Errorf("Expected 1 GetAttachment call (cached), got %d", len(mockClient.GetAttachmentCalls))
+	}
+}
+
+func TestImageProcessorWithNilClient(t *testing.T) {
+	book, err := epub.NewEpub("Test Book")
+	if err != nil {
+		t.Fatalf("Failed to create EPUB: %v", err)
+	}
+
+	// Create ImageProcessor without client
+	imgProc := &ImageProcessor{
+		client:         nil,
+		revisionID:     testRevisionID,
+		book:           book,
+		imageCache:     make(map[string]string),
+		maxImageHeight: defaultImageHeight,
+	}
+
+	fig := &jplaw.FigStruct{
+		Fig: jplaw.Fig{
+			Src: "test.png",
+		},
+	}
+
+	_, err = imgProc.ProcessFigStruct(fig)
+	if err == nil {
+		t.Error("Expected error with nil client, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "API client is not configured") {
+		t.Errorf("Expected 'API client is not configured' error, got: %v", err)
+	}
+}
+
+func TestDownloadImage(t *testing.T) {
+	tests := []struct {
+		name        string
+		src         string
+		setupMock   func(*MockAPIClient)
+		wantErr     bool
+		wantContent string
+	}{
+		{
+			name: "successful download",
+			src:  "image.jpg",
+			setupMock: func(m *MockAPIClient) {
+				data := "test image data"
+				m.GetAttachmentData = map[string]string{
+					"image.jpg": data,
+				}
+			},
+			wantErr:     false,
+			wantContent: "test image data",
+		},
+		{
+			name: "API error",
+			src:  "error.jpg",
+			setupMock: func(m *MockAPIClient) {
+				m.GetAttachmentErr = fmt.Errorf("API error")
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil attachment",
+			src:  "nil.jpg",
+			setupMock: func(m *MockAPIClient) {
+				m.GetAttachmentFunc = func(string, *lawapi.GetAttachmentParams) (*string, error) {
+					return nil, nil
+				}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockAPIClient{}
+			if tt.setupMock != nil {
+				tt.setupMock(mockClient)
+			}
+
+			imgProc := &ImageProcessor{
+				client:     mockClient,
+				revisionID: testRevisionID,
+			}
+
+			data, contentType, err := imgProc.downloadImage(tt.src)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("downloadImage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err == nil {
+				if string(data) != tt.wantContent {
+					t.Errorf("downloadImage() data = %v, want %v", string(data), tt.wantContent)
+				}
+
+				if contentType == "" {
+					t.Error("downloadImage() contentType is empty")
+				}
+			}
+
+			// Verify API was called with correct parameters
+			if len(mockClient.GetAttachmentCalls) > 0 {
+				call := mockClient.GetAttachmentCalls[0]
+				if call.RevisionID != testRevisionID {
+					t.Errorf("GetAttachment called with wrong RevisionID: %v", call.RevisionID)
+				}
+				if call.Params == nil || call.Params.Src == nil || *call.Params.Src != tt.src {
+					t.Errorf("GetAttachment called with wrong src parameter")
+				}
+			}
+		})
+	}
+}
+
+// Test ImageProcessor creation with mock client
+func TestNewImageProcessorWithMockClient(t *testing.T) {
+	mockClient := &MockAPIClient{}
+	book, _ := epub.NewEpub("Test Book")
+
+	imgProc := NewImageProcessor(mockClient, testRevisionID, book)
+
+	if imgProc.client != mockClient {
+		t.Error("ImageProcessor client not set correctly")
+	}
+
+	if imgProc.revisionID != testRevisionID {
+		t.Error("ImageProcessor revisionID not set correctly")
+	}
+
+	if imgProc.book != book {
+		t.Error("ImageProcessor book not set correctly")
+	}
+
+	if imgProc.maxImageHeight != defaultImageHeight {
+		t.Errorf("ImageProcessor default maxImageHeight = %v, want %v", imgProc.maxImageHeight, defaultImageHeight)
+	}
+
+	if imgProc.imageCache == nil {
+		t.Error("ImageProcessor imageCache not initialized")
+	}
+}
+
+// Benchmark with mock client
+func BenchmarkProcessFigStructWithMockClient(b *testing.B) {
+	mockClient := &MockAPIClient{
+		GetAttachmentData: map[string]string{
+			"bench.png": createBase64PNG(),
+		},
+	}
+
+	book, _ := epub.NewEpub("Test Book")
+	imgProc := &ImageProcessor{
+		client:         mockClient,
+		revisionID:     testRevisionID,
+		book:           book,
+		imageCache:     make(map[string]string),
+		maxImageHeight: defaultImageHeight,
+	}
+
+	fig := &jplaw.FigStruct{
+		Fig: jplaw.Fig{
+			Src: "bench.png",
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Clear cache each iteration to test full processing
+		imgProc.imageCache = make(map[string]string)
+		_, _ = imgProc.ProcessFigStruct(fig)
+	}
+}
+
+// Test for validating mock client interface compatibility
+func TestMockClientInterfaceCompatibility(t *testing.T) {
+	// This test ensures our MockAPIClient can be used wherever lawapi.Client is expected
+	var _ interface {
+		GetAttachment(string, *lawapi.GetAttachmentParams) (*string, error)
+	} = (*MockAPIClient)(nil)
+}

--- a/images_interface.go
+++ b/images_interface.go
@@ -1,0 +1,12 @@
+package jplaw2epub
+
+import "go.ngs.io/jplaw-xml"
+
+// ImageProcessorInterface defines the interface for image processing
+type ImageProcessorInterface interface {
+	ProcessFigStruct(fig *jplaw.FigStruct) (string, error)
+	SetMaxImageHeight(height string)
+}
+
+// Ensure ImageProcessor implements ImageProcessorInterface
+var _ ImageProcessorInterface = (*ImageProcessor)(nil)

--- a/images_mock_test.go
+++ b/images_mock_test.go
@@ -1,0 +1,405 @@
+package jplaw2epub
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-shiori/go-epub"
+	"go.ngs.io/jplaw-xml"
+)
+
+// MockImageProcessor is a mock implementation of ImageProcessorInterface for testing
+type MockImageProcessor struct {
+	// Control behavior
+	ProcessFigStructFunc func(*jplaw.FigStruct) (string, error)
+	ProcessFigStructErr  error
+	ProcessFigStructHTML string
+
+	// Track calls
+	ProcessFigStructCalls  []*jplaw.FigStruct
+	SetMaxImageHeightCalls []string
+}
+
+// Ensure MockImageProcessor implements ImageProcessorInterface
+var _ ImageProcessorInterface = (*MockImageProcessor)(nil)
+
+// ProcessFigStruct mocks the ProcessFigStruct method
+func (m *MockImageProcessor) ProcessFigStruct(fig *jplaw.FigStruct) (string, error) {
+	m.ProcessFigStructCalls = append(m.ProcessFigStructCalls, fig)
+
+	if m.ProcessFigStructFunc != nil {
+		return m.ProcessFigStructFunc(fig)
+	}
+
+	if m.ProcessFigStructErr != nil {
+		return "", m.ProcessFigStructErr
+	}
+
+	if m.ProcessFigStructHTML != "" {
+		return m.ProcessFigStructHTML, nil
+	}
+
+	// Default behavior - return simple HTML
+	return fmt.Sprintf(`<img src="mock-%s.png" alt="Figure"/>`, fig.Fig.Src), nil
+}
+
+// SetMaxImageHeight mocks the SetMaxImageHeight method
+func (m *MockImageProcessor) SetMaxImageHeight(height string) {
+	m.SetMaxImageHeightCalls = append(m.SetMaxImageHeightCalls, height)
+}
+
+// Test using MockImageProcessor
+func TestProcessParagraphWithImagesMocked(t *testing.T) {
+	tests := []struct {
+		name         string
+		para         *jplaw.Paragraph
+		mockBehavior func(*MockImageProcessor)
+		wantContains []string
+		wantCalls    int
+	}{
+		{
+			name: "paragraph with FigStruct - success",
+			para: &jplaw.Paragraph{
+				ParagraphNum: jplaw.ParagraphNum{Content: "1"},
+				ParagraphSentence: jplaw.ParagraphSentence{
+					Sentence: []jplaw.Sentence{{
+						MixedContent: jplaw.MixedContent{
+							Nodes: []jplaw.ContentNode{
+								jplaw.TextNode{Text: "テスト段落"},
+							},
+						},
+					}},
+				},
+				FigStruct: []jplaw.FigStruct{
+					{
+						Fig: jplaw.Fig{
+							Src: "image1.jpg",
+						},
+					},
+				},
+			},
+			mockBehavior: func(m *MockImageProcessor) {
+				m.ProcessFigStructHTML = `<div class="figure"><img src="images/image1.jpg" alt="Figure 1"/></div>`
+			},
+			wantContains: []string{
+				"テスト段落",
+				`<div class="figure"><img src="images/image1.jpg" alt="Figure 1"/></div>`,
+			},
+			wantCalls: 1,
+		},
+		{
+			name: "paragraph with multiple FigStructs",
+			para: &jplaw.Paragraph{
+				ParagraphNum: jplaw.ParagraphNum{Content: "2"},
+				ParagraphSentence: jplaw.ParagraphSentence{
+					Sentence: []jplaw.Sentence{{
+						MixedContent: jplaw.MixedContent{
+							Nodes: []jplaw.ContentNode{
+								jplaw.TextNode{Text: "複数の図"},
+							},
+						},
+					}},
+				},
+				FigStruct: []jplaw.FigStruct{
+					{Fig: jplaw.Fig{Src: "image1.jpg"}},
+					{Fig: jplaw.Fig{Src: "image2.jpg"}},
+				},
+			},
+			mockBehavior: func(m *MockImageProcessor) {
+				m.ProcessFigStructFunc = func(fig *jplaw.FigStruct) (string, error) {
+					return fmt.Sprintf(`<img src=%q alt="Fig"/>`, fig.Fig.Src), nil
+				}
+			},
+			wantContains: []string{
+				"複数の図",
+				`<img src="image1.jpg" alt="Fig"/>`,
+				`<img src="image2.jpg" alt="Fig"/>`,
+			},
+			wantCalls: 2,
+		},
+		{
+			name: "paragraph with FigStruct - error handling",
+			para: &jplaw.Paragraph{
+				ParagraphNum: jplaw.ParagraphNum{Content: "3"},
+				ParagraphSentence: jplaw.ParagraphSentence{
+					Sentence: []jplaw.Sentence{{
+						MixedContent: jplaw.MixedContent{
+							Nodes: []jplaw.ContentNode{
+								jplaw.TextNode{Text: "エラーテスト"},
+							},
+						},
+					}},
+				},
+				FigStruct: []jplaw.FigStruct{
+					{Fig: jplaw.Fig{Src: "error.jpg"}},
+				},
+			},
+			mockBehavior: func(m *MockImageProcessor) {
+				m.ProcessFigStructErr = fmt.Errorf("image processing failed")
+			},
+			wantContains: []string{
+				"エラーテスト",
+				// Error case - image HTML should not be included
+			},
+			wantCalls: 1,
+		},
+		{
+			name: "paragraph without FigStruct",
+			para: &jplaw.Paragraph{
+				ParagraphNum: jplaw.ParagraphNum{Content: "4"},
+				ParagraphSentence: jplaw.ParagraphSentence{
+					Sentence: []jplaw.Sentence{{
+						MixedContent: jplaw.MixedContent{
+							Nodes: []jplaw.ContentNode{
+								jplaw.TextNode{Text: "図なし"},
+							},
+						},
+					}},
+				},
+				FigStruct: []jplaw.FigStruct{},
+			},
+			mockBehavior: func(m *MockImageProcessor) {
+				// No special behavior needed
+			},
+			wantContains: []string{
+				"図なし",
+			},
+			wantCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock
+			mock := &MockImageProcessor{}
+			if tt.mockBehavior != nil {
+				tt.mockBehavior(mock)
+			}
+
+			// Call the function with mock
+			result := processParagraphWithImages(tt.para, mock)
+
+			// Verify the HTML contains expected content
+			for _, want := range tt.wantContains {
+				if !contains(result, want) {
+					t.Errorf("Result should contain %q, got: %v", want, result)
+				}
+			}
+
+			// Verify the number of calls
+			if len(mock.ProcessFigStructCalls) != tt.wantCalls {
+				t.Errorf("Expected %d calls to ProcessFigStruct, got %d",
+					tt.wantCalls, len(mock.ProcessFigStructCalls))
+			}
+
+			// Verify the correct FigStructs were passed
+			if tt.wantCalls > 0 && len(tt.para.FigStruct) > 0 {
+				for i, call := range mock.ProcessFigStructCalls {
+					if call.Fig.Src != tt.para.FigStruct[i].Fig.Src {
+						t.Errorf("Call %d: expected Src %q, got %q",
+							i, tt.para.FigStruct[i].Fig.Src, call.Fig.Src)
+					}
+				}
+			}
+		})
+	}
+}
+
+// Test for processChapterWithImages using mock
+func TestProcessChapterWithImagesMocked(t *testing.T) {
+	book, err := epub.NewEpub("Test Book")
+	if err != nil {
+		t.Fatalf("Failed to create EPUB: %v", err)
+	}
+
+	chapter := &jplaw.Chapter{
+		ChapterTitle: jplaw.ChapterTitle{
+			Content: "第一章",
+		},
+		Article: []jplaw.Article{
+			{
+				ArticleTitle: &jplaw.ArticleTitle{
+					Content: "第一条",
+				},
+				Paragraph: []jplaw.Paragraph{
+					{
+						ParagraphSentence: jplaw.ParagraphSentence{
+							Sentence: []jplaw.Sentence{{
+								MixedContent: jplaw.MixedContent{
+									Nodes: []jplaw.ContentNode{
+										jplaw.TextNode{Text: "条文内容"},
+									},
+								},
+							}},
+						},
+						FigStruct: []jplaw.FigStruct{
+							{Fig: jplaw.Fig{Src: "article_image.jpg"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("with mock image processor", func(t *testing.T) {
+		mock := &MockImageProcessor{
+			ProcessFigStructHTML: `<div class="article-figure"><img src="processed.jpg"/></div>`,
+		}
+
+		err := processChapterWithImages(book, chapter, 0, mock)
+		if err != nil {
+			t.Errorf("processChapterWithImages() error = %v", err)
+		}
+
+		// Verify ProcessFigStruct was called
+		if len(mock.ProcessFigStructCalls) != 1 {
+			t.Errorf("Expected 1 call to ProcessFigStruct, got %d", len(mock.ProcessFigStructCalls))
+		}
+	})
+
+	t.Run("with nil image processor", func(t *testing.T) {
+		// Should not panic with nil processor
+		err := processChapterWithImages(book, chapter, 1, nil)
+		if err != nil {
+			t.Errorf("processChapterWithImages() with nil processor error = %v", err)
+		}
+	})
+}
+
+// Test for processMainProvision with mock
+func TestProcessMainProvisionWithMock(t *testing.T) {
+	book, err := epub.NewEpub("Test Book")
+	if err != nil {
+		t.Fatalf("Failed to create EPUB: %v", err)
+	}
+
+	mainProv := &jplaw.MainProvision{
+		Paragraph: []jplaw.Paragraph{
+			{
+				Num:          1,
+				ParagraphNum: jplaw.ParagraphNum{Content: "1"},
+				ParagraphSentence: jplaw.ParagraphSentence{
+					Sentence: []jplaw.Sentence{{
+						MixedContent: jplaw.MixedContent{
+							Nodes: []jplaw.ContentNode{
+								jplaw.TextNode{Text: "第一項"},
+							},
+						},
+					}},
+				},
+				FigStruct: []jplaw.FigStruct{
+					{Fig: jplaw.Fig{Src: "para1.jpg"}},
+				},
+			},
+			{
+				Num:          2,
+				ParagraphNum: jplaw.ParagraphNum{Content: "2"},
+				ParagraphSentence: jplaw.ParagraphSentence{
+					Sentence: []jplaw.Sentence{{
+						MixedContent: jplaw.MixedContent{
+							Nodes: []jplaw.ContentNode{
+								jplaw.TextNode{Text: "第二項"},
+							},
+						},
+					}},
+				},
+				FigStruct: []jplaw.FigStruct{
+					{Fig: jplaw.Fig{Src: "para2.jpg"}},
+				},
+			},
+		},
+	}
+
+	t.Run("multiple paragraphs with images", func(t *testing.T) {
+		callCount := 0
+		mock := &MockImageProcessor{
+			ProcessFigStructFunc: func(fig *jplaw.FigStruct) (string, error) {
+				callCount++
+				return fmt.Sprintf(`<img src="mock-%d.jpg" alt="Mock %d"/>`, callCount, callCount), nil
+			},
+		}
+
+		err := processMainProvision(book, mainProv, mock)
+		if err != nil {
+			t.Errorf("processMainProvision() error = %v", err)
+		}
+
+		// Verify both FigStructs were processed
+		if len(mock.ProcessFigStructCalls) != 2 {
+			t.Errorf("Expected 2 calls to ProcessFigStruct, got %d", len(mock.ProcessFigStructCalls))
+		}
+
+		// Verify the correct images were processed
+		if mock.ProcessFigStructCalls[0].Fig.Src != "para1.jpg" {
+			t.Errorf("First call: expected Src 'para1.jpg', got %q", mock.ProcessFigStructCalls[0].Fig.Src)
+		}
+		if mock.ProcessFigStructCalls[1].Fig.Src != "para2.jpg" {
+			t.Errorf("Second call: expected Src 'para2.jpg', got %q", mock.ProcessFigStructCalls[1].Fig.Src)
+		}
+	})
+}
+
+// Helper function for testing
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || substr == "" ||
+		(s != "" && substr != "" &&
+			(s[0:len(substr)] == substr || contains(s[1:], substr))))
+}
+
+// Test for createImageProcessor with options
+func TestCreateImageProcessorWithOptions(t *testing.T) {
+	book, err := epub.NewEpub("Test Book")
+	if err != nil {
+		t.Fatalf("Failed to create EPUB: %v", err)
+	}
+
+	t.Run("with nil options", func(t *testing.T) {
+		imgProc := createImageProcessor(book, nil)
+		if imgProc != nil {
+			t.Errorf("Expected nil processor for nil options, got %v", imgProc)
+		}
+	})
+
+	t.Run("with empty options", func(t *testing.T) {
+		opts := &EPUBOptions{}
+		imgProc := createImageProcessor(book, opts)
+		if imgProc != nil {
+			t.Errorf("Expected nil processor for empty options, got %v", imgProc)
+		}
+	})
+
+	// Note: Full ImageProcessor creation requires API client,
+	// which we can't easily test without external dependencies
+}
+
+// Benchmark with mock
+func BenchmarkProcessParagraphWithMockImages(b *testing.B) {
+	para := &jplaw.Paragraph{
+		ParagraphNum: jplaw.ParagraphNum{Content: "1"},
+		ParagraphSentence: jplaw.ParagraphSentence{
+			Sentence: []jplaw.Sentence{{
+				MixedContent: jplaw.MixedContent{
+					Nodes: []jplaw.ContentNode{
+						jplaw.TextNode{Text: "ベンチマークテスト"},
+					},
+				},
+			}},
+		},
+		FigStruct: []jplaw.FigStruct{
+			{Fig: jplaw.Fig{Src: "bench1.jpg"}},
+			{Fig: jplaw.Fig{Src: "bench2.jpg"}},
+			{Fig: jplaw.Fig{Src: "bench3.jpg"}},
+		},
+	}
+
+	mock := &MockImageProcessor{
+		ProcessFigStructFunc: func(fig *jplaw.FigStruct) (string, error) {
+			return fmt.Sprintf(`<img src=%q/>`, fig.Fig.Src), nil
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = processParagraphWithImages(para, mock)
+	}
+}

--- a/item.go
+++ b/item.go
@@ -13,7 +13,7 @@ func processItems(items []jplaw.Item) string {
 }
 
 // processItemsWithImages processes a list of items with image support
-func processItemsWithImages(items []jplaw.Item, imgProc *ImageProcessor) string {
+func processItemsWithImages(items []jplaw.Item, imgProc ImageProcessorInterface) string {
 	if len(items) == 0 {
 		return ""
 	}
@@ -36,7 +36,7 @@ func processItem(item *jplaw.Item) string {
 }
 
 // processItemWithImages processes a single item with image support
-func processItemWithImages(item *jplaw.Item, imgProc *ImageProcessor) string {
+func processItemWithImages(item *jplaw.Item, imgProc ImageProcessorInterface) string {
 	body := htmlLI
 
 	// Add item title if not a list number
@@ -88,7 +88,7 @@ func processItemWithImages(item *jplaw.Item, imgProc *ImageProcessor) string {
 }
 
 // processSubitem1ListWithImages processes a list of Subitem1 with image support
-func processSubitem1ListWithImages(subitems []jplaw.Subitem1, imgProc *ImageProcessor) string {
+func processSubitem1ListWithImages(subitems []jplaw.Subitem1, imgProc ImageProcessorInterface) string {
 	titles := collectSubitem1Titles(subitems)
 	body := openListWithStyle(titles)
 
@@ -106,7 +106,7 @@ func processSubitem1(subitem *jplaw.Subitem1) string {
 }
 
 // processSubitem1WithImages processes a single Subitem1 with image support
-func processSubitem1WithImages(subitem *jplaw.Subitem1, imgProc *ImageProcessor) string {
+func processSubitem1WithImages(subitem *jplaw.Subitem1, imgProc ImageProcessorInterface) string {
 	body := htmlLI
 
 	// Add title if not a list number
@@ -145,7 +145,7 @@ func processSubitem1WithImages(subitem *jplaw.Subitem1, imgProc *ImageProcessor)
 }
 
 // processSubitem2ListWithImages processes a list of Subitem2 with image support
-func processSubitem2ListWithImages(subitems []jplaw.Subitem2, imgProc *ImageProcessor) string {
+func processSubitem2ListWithImages(subitems []jplaw.Subitem2, imgProc ImageProcessorInterface) string {
 	titles := collectSubitem2Titles(subitems)
 	body := openListWithStyle(titles)
 
@@ -163,7 +163,7 @@ func processSubitem2(subitem *jplaw.Subitem2) string {
 }
 
 // processSubitem2WithImages processes a single Subitem2 with image support
-func processSubitem2WithImages(subitem *jplaw.Subitem2, imgProc *ImageProcessor) string {
+func processSubitem2WithImages(subitem *jplaw.Subitem2, imgProc ImageProcessorInterface) string {
 	body := htmlLI
 
 	// Add title if not a list number

--- a/jplaw2epub.go
+++ b/jplaw2epub.go
@@ -168,7 +168,7 @@ func createEPUBFromData(data *jplaw.Law) (*epub.Epub, error) {
 }
 
 // createImageProcessor creates an image processor from options
-func createImageProcessor(book *epub.Epub, opts *EPUBOptions) *ImageProcessor {
+func createImageProcessor(book *epub.Epub, opts *EPUBOptions) ImageProcessorInterface {
 	if opts == nil || opts.APIClient == nil || opts.RevisionID == "" {
 		return nil
 	}

--- a/main_provision.go
+++ b/main_provision.go
@@ -8,7 +8,7 @@ import (
 )
 
 // processMainProvision processes the main provision content
-func processMainProvision(book *epub.Epub, mainProv *jplaw.MainProvision, imgProc *ImageProcessor) error {
+func processMainProvision(book *epub.Epub, mainProv *jplaw.MainProvision, imgProc ImageProcessorInterface) error {
 	if len(mainProv.Chapter) > 0 {
 		// Process chapters
 		for i := range mainProv.Chapter {

--- a/paragraph.go
+++ b/paragraph.go
@@ -12,7 +12,7 @@ import (
 type paragraphProcessor struct {
 	inList         bool
 	body           string
-	imageProcessor *ImageProcessor
+	imageProcessor ImageProcessorInterface
 }
 
 // processParagraphs processes all paragraphs in an article
@@ -21,7 +21,7 @@ func processParagraphs(paragraphs []jplaw.Paragraph) string {
 }
 
 // processParagraphWithImages processes a single paragraph with image support
-func processParagraphWithImages(para *jplaw.Paragraph, imgProc *ImageProcessor) string {
+func processParagraphWithImages(para *jplaw.Paragraph, imgProc ImageProcessorInterface) string {
 	p := &paragraphProcessor{imageProcessor: imgProc}
 
 	if para.Num > 0 {
@@ -72,7 +72,7 @@ func processParagraphWithImages(para *jplaw.Paragraph, imgProc *ImageProcessor) 
 }
 
 // processParagraphsWithImages processes all paragraphs with image support
-func processParagraphsWithImages(paragraphs []jplaw.Paragraph, imgProc *ImageProcessor) string {
+func processParagraphsWithImages(paragraphs []jplaw.Paragraph, imgProc ImageProcessorInterface) string {
 	p := &paragraphProcessor{imageProcessor: imgProc}
 
 	for i := range paragraphs {

--- a/paragraph_list_test.go
+++ b/paragraph_list_test.go
@@ -1,0 +1,643 @@
+package jplaw2epub
+
+import (
+	"strings"
+	"testing"
+
+	"go.ngs.io/jplaw-xml"
+)
+
+// Helper function to create test sentence with MixedContent
+func createTestSentenceWithContent(text string) jplaw.Sentence {
+	return jplaw.Sentence{
+		MixedContent: jplaw.MixedContent{
+			Nodes: []jplaw.ContentNode{
+				jplaw.TextNode{Text: text},
+			},
+		},
+	}
+}
+
+func TestProcessLists(t *testing.T) {
+	tests := []struct {
+		name     string
+		lists    []jplaw.List
+		want     string
+		contains []string
+	}{
+		{
+			name:  "empty lists",
+			lists: []jplaw.List{},
+			want:  "",
+		},
+		{
+			name: "single list with sentence",
+			lists: []jplaw.List{
+				{
+					ListSentence: jplaw.ListSentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("リスト項目1"),
+						},
+					},
+				},
+			},
+			contains: []string{
+				`<ul class="law-list">`,
+				`<li>`,
+				"リスト項目1",
+				`</li>`,
+				`</ul>`,
+			},
+		},
+		{
+			name: "multiple lists",
+			lists: []jplaw.List{
+				{
+					ListSentence: jplaw.ListSentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("項目A"),
+						},
+					},
+				},
+				{
+					ListSentence: jplaw.ListSentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("項目B"),
+						},
+					},
+				},
+			},
+			contains: []string{
+				`<ul class="law-list">`,
+				"項目A",
+				"項目B",
+				`</ul>`,
+			},
+		},
+		{
+			name: "list with sublist1",
+			lists: []jplaw.List{
+				{
+					ListSentence: jplaw.ListSentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("親リスト"),
+						},
+					},
+					Sublist1: []jplaw.Sublist1{
+						{
+							Sublist1Sentence: jplaw.Sublist1Sentence{
+								Sentence: []jplaw.Sentence{
+									createTestSentenceWithContent("サブリスト1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			contains: []string{
+				"親リスト",
+				`<ul class="law-sublist1">`,
+				"サブリスト1",
+			},
+		},
+		{
+			name: "list with columns",
+			lists: []jplaw.List{
+				{
+					ListSentence: jplaw.ListSentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("リスト内容"),
+						},
+						Column: []jplaw.Column{
+							{
+								Num:       1,
+								LineBreak: false,
+								Sentence: []jplaw.Sentence{
+									createTestSentenceWithContent("欄1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			contains: []string{
+				"リスト内容",
+				"欄1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := processLists(tt.lists)
+
+			if tt.want != "" && got != tt.want {
+				t.Errorf("processLists() = %v, want %v", got, tt.want)
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("processLists() missing expected content: %s", want)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessSublist1(t *testing.T) {
+	tests := []struct {
+		name     string
+		sublists []jplaw.Sublist1
+		want     string
+		contains []string
+	}{
+		{
+			name:     "empty sublist1",
+			sublists: []jplaw.Sublist1{},
+			want:     "",
+		},
+		{
+			name: "single sublist1",
+			sublists: []jplaw.Sublist1{
+				{
+					Sublist1Sentence: jplaw.Sublist1Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("サブリスト1項目"),
+						},
+					},
+				},
+			},
+			contains: []string{
+				`<ul class="law-sublist1">`,
+				`<li>`,
+				"サブリスト1項目",
+				`</li>`,
+				`</ul>`,
+			},
+		},
+		{
+			name: "sublist1 with sublist2",
+			sublists: []jplaw.Sublist1{
+				{
+					Sublist1Sentence: jplaw.Sublist1Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("レベル1"),
+						},
+					},
+					Sublist2: []jplaw.Sublist2{
+						{
+							Sublist2Sentence: jplaw.Sublist2Sentence{
+								Sentence: []jplaw.Sentence{
+									createTestSentenceWithContent("レベル2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			contains: []string{
+				`<ul class="law-sublist1">`,
+				"レベル1",
+				`<ul class="law-sublist2">`,
+				"レベル2",
+			},
+		},
+		{
+			name: "sublist1 with columns",
+			sublists: []jplaw.Sublist1{
+				{
+					Sublist1Sentence: jplaw.Sublist1Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("サブリスト内容"),
+						},
+						Column: []jplaw.Column{
+							{
+								Num: 1,
+								Sentence: []jplaw.Sentence{
+									createTestSentenceWithContent("欄内容"),
+								},
+							},
+						},
+					},
+				},
+			},
+			contains: []string{
+				"サブリスト内容",
+				"欄内容",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := processSublist1(tt.sublists)
+
+			if tt.want != "" && got != tt.want {
+				t.Errorf("processSublist1() = %v, want %v", got, tt.want)
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("processSublist1() missing expected content: %s", want)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessSublist2(t *testing.T) {
+	tests := []struct {
+		name     string
+		sublists []jplaw.Sublist2
+		want     string
+		contains []string
+	}{
+		{
+			name:     "empty sublist2",
+			sublists: []jplaw.Sublist2{},
+			want:     "",
+		},
+		{
+			name: "single sublist2",
+			sublists: []jplaw.Sublist2{
+				{
+					Sublist2Sentence: jplaw.Sublist2Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("サブリスト2項目"),
+						},
+					},
+				},
+			},
+			contains: []string{
+				`<ul class="law-sublist2">`,
+				`<li>`,
+				"サブリスト2項目",
+				`</li>`,
+				`</ul>`,
+			},
+		},
+		{
+			name: "sublist2 with sublist3",
+			sublists: []jplaw.Sublist2{
+				{
+					Sublist2Sentence: jplaw.Sublist2Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("レベル2"),
+						},
+					},
+					Sublist3: []jplaw.Sublist3{
+						{
+							Sublist3Sentence: jplaw.Sublist3Sentence{
+								Sentence: []jplaw.Sentence{
+									createTestSentenceWithContent("レベル3"),
+								},
+							},
+						},
+					},
+				},
+			},
+			contains: []string{
+				`<ul class="law-sublist2">`,
+				"レベル2",
+				`<ul class="law-sublist3">`,
+				"レベル3",
+			},
+		},
+		{
+			name: "multiple sublist2 items",
+			sublists: []jplaw.Sublist2{
+				{
+					Sublist2Sentence: jplaw.Sublist2Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("項目2-1"),
+						},
+					},
+				},
+				{
+					Sublist2Sentence: jplaw.Sublist2Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("項目2-2"),
+						},
+					},
+				},
+			},
+			contains: []string{
+				"項目2-1",
+				"項目2-2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := processSublist2(tt.sublists)
+
+			if tt.want != "" && got != tt.want {
+				t.Errorf("processSublist2() = %v, want %v", got, tt.want)
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("processSublist2() missing expected content: %s\nGot: %s", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessSublist3(t *testing.T) {
+	tests := []struct {
+		name     string
+		sublists []jplaw.Sublist3
+		want     string
+		contains []string
+	}{
+		{
+			name:     "empty sublist3",
+			sublists: []jplaw.Sublist3{},
+			want:     "",
+		},
+		{
+			name: "single sublist3",
+			sublists: []jplaw.Sublist3{
+				{
+					Sublist3Sentence: jplaw.Sublist3Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("サブリスト3項目"),
+						},
+					},
+				},
+			},
+			contains: []string{
+				`<ul class="law-sublist3">`,
+				`<li>`,
+				"サブリスト3項目",
+				`</li>`,
+				`</ul>`,
+			},
+		},
+		{
+			name: "multiple sublist3 items",
+			sublists: []jplaw.Sublist3{
+				{
+					Sublist3Sentence: jplaw.Sublist3Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("項目3-1"),
+						},
+					},
+				},
+				{
+					Sublist3Sentence: jplaw.Sublist3Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("項目3-2"),
+						},
+					},
+				},
+			},
+			contains: []string{
+				`<ul class="law-sublist3">`,
+				"項目3-1",
+				"項目3-2",
+				`</ul>`,
+			},
+		},
+		{
+			name: "sublist3 with columns",
+			sublists: []jplaw.Sublist3{
+				{
+					Sublist3Sentence: jplaw.Sublist3Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("リスト3内容"),
+						},
+						Column: []jplaw.Column{
+							{
+								Num: 1,
+								Sentence: []jplaw.Sentence{
+									createTestSentenceWithContent("欄3内容"),
+								},
+							},
+						},
+					},
+				},
+			},
+			contains: []string{
+				"リスト3内容",
+				"欄3内容",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := processSublist3(tt.sublists)
+
+			if tt.want != "" && got != tt.want {
+				t.Errorf("processSublist3() = %v, want %v", got, tt.want)
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("processSublist3() missing expected content: %s", want)
+				}
+			}
+		})
+	}
+}
+
+// Test for nested list structure
+func TestProcessListsNested(t *testing.T) {
+	// Create a deeply nested list structure
+	lists := []jplaw.List{
+		{
+			ListSentence: jplaw.ListSentence{
+				Sentence: []jplaw.Sentence{
+					createTestSentenceWithContent("レベル0"),
+				},
+			},
+			Sublist1: []jplaw.Sublist1{
+				{
+					Sublist1Sentence: jplaw.Sublist1Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("レベル1"),
+						},
+					},
+					Sublist2: []jplaw.Sublist2{
+						{
+							Sublist2Sentence: jplaw.Sublist2Sentence{
+								Sentence: []jplaw.Sentence{
+									createTestSentenceWithContent("レベル2"),
+								},
+							},
+							Sublist3: []jplaw.Sublist3{
+								{
+									Sublist3Sentence: jplaw.Sublist3Sentence{
+										Sentence: []jplaw.Sentence{
+											createTestSentenceWithContent("レベル3"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := processLists(lists)
+
+	expectedContent := []string{
+		`<ul class="law-list">`,
+		"レベル0",
+		`<ul class="law-sublist1">`,
+		"レベル1",
+		`<ul class="law-sublist2">`,
+		"レベル2",
+		`<ul class="law-sublist3">`,
+		"レベル3",
+	}
+
+	for _, want := range expectedContent {
+		if !strings.Contains(got, want) {
+			t.Errorf("processLists() missing expected nested content: %s", want)
+		}
+	}
+}
+
+// Benchmark tests
+func BenchmarkProcessLists(b *testing.B) {
+	lists := []jplaw.List{
+		{
+			ListSentence: jplaw.ListSentence{
+				Sentence: []jplaw.Sentence{
+					createTestSentenceWithContent("ベンチマークリスト"),
+				},
+			},
+			Sublist1: []jplaw.Sublist1{
+				{
+					Sublist1Sentence: jplaw.Sublist1Sentence{
+						Sentence: []jplaw.Sentence{
+							createTestSentenceWithContent("サブリスト"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = processLists(lists)
+	}
+}
+
+func BenchmarkProcessSublist1(b *testing.B) {
+	sublists := []jplaw.Sublist1{
+		{
+			Sublist1Sentence: jplaw.Sublist1Sentence{
+				Sentence: []jplaw.Sentence{
+					createTestSentenceWithContent("ベンチマーク項目1"),
+					createTestSentenceWithContent("ベンチマーク項目2"),
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = processSublist1(sublists)
+	}
+}
+
+// Test for edge cases in processNumberedParagraph
+func TestProcessNumberedParagraphEdgeCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		para       *jplaw.Paragraph
+		nextPara   *jplaw.Paragraph
+		wantInList bool
+		contains   []string
+	}{
+		{
+			name: "numbered paragraph with list",
+			para: &jplaw.Paragraph{
+				Num:          1,
+				ParagraphNum: jplaw.ParagraphNum{Content: "1"},
+				ParagraphSentence: jplaw.ParagraphSentence{
+					Sentence: []jplaw.Sentence{
+						createTestSentenceWithContent("段落内容"),
+					},
+				},
+				List: []jplaw.List{
+					{
+						ListSentence: jplaw.ListSentence{
+							Sentence: []jplaw.Sentence{
+								createTestSentenceWithContent("リスト項目"),
+							},
+						},
+					},
+				},
+			},
+			nextPara: &jplaw.Paragraph{
+				Num: 2,
+			},
+			wantInList: true,
+			contains: []string{
+				"段落内容",
+				"リスト項目",
+				`<ul class="law-list">`,
+			},
+		},
+		{
+			name: "numbered paragraph with table",
+			para: &jplaw.Paragraph{
+				Num:          1,
+				ParagraphNum: jplaw.ParagraphNum{Content: "1"},
+				ParagraphSentence: jplaw.ParagraphSentence{
+					Sentence: []jplaw.Sentence{
+						createTestSentenceWithContent("表を含む段落"),
+					},
+				},
+				TableStruct: []jplaw.TableStruct{
+					{
+						TableStructTitle: &jplaw.TableStructTitle{
+							Content: "表1",
+						},
+					},
+				},
+			},
+			nextPara:   nil,
+			wantInList: true, // processNumberedParagraph always sets inList to true
+			contains: []string{
+				"表を含む段落",
+				"表1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &paragraphProcessor{
+				inList: false,
+			}
+
+			// Create a slice with the test paragraph
+			paragraphs := []jplaw.Paragraph{*tt.para}
+			if tt.nextPara != nil {
+				paragraphs = append(paragraphs, *tt.nextPara)
+			}
+
+			p.processNumberedParagraph(tt.para, 0, paragraphs)
+
+			if p.inList != tt.wantInList {
+				t.Errorf("processNumberedParagraph() inList = %v, want %v", p.inList, tt.wantInList)
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(p.body, want) {
+					t.Errorf("processNumberedParagraph() missing expected content: %s", want)
+				}
+			}
+		})
+	}
+}

--- a/processor.go
+++ b/processor.go
@@ -18,7 +18,7 @@ func processArticlesWithImages(
 	articles []jplaw.Article,
 	parentFilename string,
 	chapterIdx, sectionIdx int,
-	imgProc *ImageProcessor,
+	imgProc ImageProcessorInterface,
 ) error {
 	for j := range articles {
 		if err := processArticleWithImages(book, &articles[j], parentFilename, chapterIdx, sectionIdx, j, imgProc); err != nil {
@@ -39,7 +39,7 @@ func processArticleWithImages(
 	article *jplaw.Article,
 	parentFilename string,
 	chapterIdx, sectionIdx, articleIdx int,
-	imgProc *ImageProcessor,
+	imgProc ImageProcessorInterface,
 ) error {
 	subFilename := buildArticleFilename(chapterIdx, sectionIdx, articleIdx)
 	articleTitle := buildArticleTitle(article)
@@ -67,7 +67,7 @@ func buildArticleBody(article *jplaw.Article, articleTitle string) string {
 }
 
 // buildArticleBodyWithImages builds the HTML body for an article with image support
-func buildArticleBodyWithImages(article *jplaw.Article, articleTitle string, imgProc *ImageProcessor) string {
+func buildArticleBodyWithImages(article *jplaw.Article, articleTitle string, imgProc ImageProcessorInterface) string {
 	body := fmt.Sprintf("<h3>%s</h3>", articleTitle)
 	body += processParagraphsWithImages(article.Paragraph, imgProc)
 	return body

--- a/style.go
+++ b/style.go
@@ -10,11 +10,11 @@ import (
 
 // StyleProcessor handles StyleStruct processing
 type StyleProcessor struct {
-	imageProcessor *ImageProcessor
+	imageProcessor ImageProcessorInterface
 }
 
 // NewStyleProcessor creates a new style processor
-func NewStyleProcessor(imgProc *ImageProcessor) *StyleProcessor {
+func NewStyleProcessor(imgProc ImageProcessorInterface) *StyleProcessor {
 	return &StyleProcessor{
 		imageProcessor: imgProc,
 	}
@@ -107,7 +107,7 @@ func (sp *StyleProcessor) processStyleContent(content string) string {
 }
 
 // ProcessStyleStructs processes multiple StyleStructs
-func ProcessStyleStructs(styles []jplaw.StyleStruct, imgProc *ImageProcessor) string {
+func ProcessStyleStructs(styles []jplaw.StyleStruct, imgProc ImageProcessorInterface) string {
 	if len(styles) == 0 {
 		return ""
 	}

--- a/suppl_provision.go
+++ b/suppl_provision.go
@@ -10,7 +10,7 @@ import (
 const defaultSupplProvisionTitle = "附則"
 
 // processSupplProvisions processes supplementary provisions
-func processSupplProvisions(book *epub.Epub, provisions []jplaw.SupplProvision, imgProc *ImageProcessor) error {
+func processSupplProvisions(book *epub.Epub, provisions []jplaw.SupplProvision, imgProc ImageProcessorInterface) error {
 	if len(provisions) == 0 {
 		return nil
 	}
@@ -25,7 +25,7 @@ func processSupplProvisions(book *epub.Epub, provisions []jplaw.SupplProvision, 
 }
 
 // processSupplProvision processes a single supplementary provision
-func processSupplProvision(book *epub.Epub, provision *jplaw.SupplProvision, idx int, imgProc *ImageProcessor) error {
+func processSupplProvision(book *epub.Epub, provision *jplaw.SupplProvision, idx int, imgProc ImageProcessorInterface) error {
 	filename := fmt.Sprintf("suppl-provision-%d.xhtml", idx)
 
 	// Build the body content
@@ -48,7 +48,7 @@ func processSupplProvision(book *epub.Epub, provision *jplaw.SupplProvision, idx
 }
 
 // buildSupplProvisionBody builds the HTML body for a supplementary provision
-func buildSupplProvisionBody(provision *jplaw.SupplProvision, imgProc *ImageProcessor) string {
+func buildSupplProvisionBody(provision *jplaw.SupplProvision, imgProc ImageProcessorInterface) string {
 	var body string
 
 	// Add title
@@ -86,7 +86,7 @@ func getSupplProvisionTitle(provision *jplaw.SupplProvision) string {
 }
 
 // processSupplProvisionChapters processes chapters in a supplementary provision
-func processSupplProvisionChapters(provision *jplaw.SupplProvision, imgProc *ImageProcessor) string {
+func processSupplProvisionChapters(provision *jplaw.SupplProvision, imgProc ImageProcessorInterface) string {
 	if len(provision.Chapter) == 0 {
 		return ""
 	}
@@ -101,7 +101,7 @@ func processSupplProvisionChapters(provision *jplaw.SupplProvision, imgProc *Ima
 }
 
 // processSupplProvisionArticles processes articles
-func processSupplProvisionArticles(articles []jplaw.Article, imgProc *ImageProcessor) string {
+func processSupplProvisionArticles(articles []jplaw.Article, imgProc ImageProcessorInterface) string {
 	if len(articles) == 0 {
 		return ""
 	}
@@ -116,7 +116,7 @@ func processSupplProvisionArticles(articles []jplaw.Article, imgProc *ImageProce
 }
 
 // processSupplProvisionAppendixes processes all appendix types
-func processSupplProvisionAppendixes(provision *jplaw.SupplProvision, imgProc *ImageProcessor) string {
+func processSupplProvisionAppendixes(provision *jplaw.SupplProvision, imgProc ImageProcessorInterface) string {
 	var body string
 
 	// Process appendix tables
@@ -138,7 +138,7 @@ func processSupplProvisionAppendixes(provision *jplaw.SupplProvision, imgProc *I
 }
 
 // processSupplProvisionAppdxTable processes supplementary provision appendix table
-func processSupplProvisionAppdxTable(table *jplaw.SupplProvisionAppdxTable, imgProc *ImageProcessor) string {
+func processSupplProvisionAppdxTable(table *jplaw.SupplProvisionAppdxTable, imgProc ImageProcessorInterface) string {
 	body := `<div class="suppl-appdx-table">`
 
 	// Add title if present
@@ -163,7 +163,7 @@ func processSupplProvisionAppdxTable(table *jplaw.SupplProvisionAppdxTable, imgP
 }
 
 // processSupplProvisionAppdxStyle processes supplementary provision appendix style
-func processSupplProvisionAppdxStyle(style *jplaw.SupplProvisionAppdxStyle, imgProc *ImageProcessor) string {
+func processSupplProvisionAppdxStyle(style *jplaw.SupplProvisionAppdxStyle, imgProc ImageProcessorInterface) string {
 	body := `<div class="suppl-appdx-style">`
 
 	// Add title if present
@@ -188,7 +188,7 @@ func processSupplProvisionAppdxStyle(style *jplaw.SupplProvisionAppdxStyle, imgP
 }
 
 // processSupplProvisionAppdx processes supplementary provision appendix
-func processSupplProvisionAppdx(appdx *jplaw.SupplProvisionAppdx, _ *ImageProcessor) string {
+func processSupplProvisionAppdx(appdx *jplaw.SupplProvisionAppdx, _ ImageProcessorInterface) string {
 	body := `<div class="suppl-appdx">`
 
 	// Add arithmetic formula number if present

--- a/table.go
+++ b/table.go
@@ -10,7 +10,7 @@ import (
 )
 
 // processTableStructs processes multiple table structures
-func processTableStructs(tables []jplaw.TableStruct, imgProc *ImageProcessor) string {
+func processTableStructs(tables []jplaw.TableStruct, imgProc ImageProcessorInterface) string {
 	if len(tables) == 0 {
 		return ""
 	}
@@ -23,7 +23,7 @@ func processTableStructs(tables []jplaw.TableStruct, imgProc *ImageProcessor) st
 }
 
 // processTableStructWithImages processes a single table structure with image support
-func processTableStructWithImages(tableStruct *jplaw.TableStruct, _ *ImageProcessor) string {
+func processTableStructWithImages(tableStruct *jplaw.TableStruct, _ ImageProcessorInterface) string {
 	var body strings.Builder
 
 	// Add table title if present


### PR DESCRIPTION
Introduce interfaces for better testability and modularity of image processing
functionality. Key changes include:

- Add `APIClient` interface to abstract law API client operations, enabling
  easier mocking in tests
- Create `ImageProcessorInterface` to decouple image processing from concrete
  implementations
- Add comprehensive test coverage for format processing with mock clients
- Implement mock image processor and API client for testing
- Update all functions to use interfaces instead of concrete types

This refactoring improves code maintainability, testability, and follows
Go best practices for dependency injection and interface segregation.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
